### PR TITLE
Change unicode type to str in tasmota.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 *.pyc
+.venv

--- a/action_plugins/tasmota.py
+++ b/action_plugins/tasmota.py
@@ -7,6 +7,7 @@ __metaclass__ = type
 
 import requests
 import json
+import sys
 
 from ansible.module_utils._text import to_native
 from ansible.plugins.action import ActionBase
@@ -17,6 +18,9 @@ try:
 except ImportError:
     from ansible.utils.display import Display
     display = Display()
+
+if sys.version_info[0] >= 3:
+    unicode = str
 
 class ActionModule(ActionBase):
     TRANSFERS_FILES = False


### PR DESCRIPTION
This PR fixes an issue that occurs when the action plugin is called by Ansible using a Python3 backend:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NameError: name 'unicode' is not defined
fatal: [<host>]: FAILED! => {"msg": "Unexpected failure during module execution.", "stdout": ""}
```

Derived from [this](https://stackoverflow.com/a/53286631/6482759) SO answer.