### PR TITLE
Add support for TimeStd / TimeDst

### DIFF
--- a/action_plugins/tasmota.py
+++ b/action_plugins/tasmota.py
@@ -123,6 +123,16 @@ class ActionModule(ActionBase):
             existing_value = next(iter(modules_ids))
         elif (command == 'Template'):
             existing_value = data
+        elif (command == 'TimeStd' or command == 'TimeDst' ):
+            display.vv("TimeStd/TimeDst found!");
+            existing_data = data.get(command);
+            existing_day = existing_data.get("Day");
+            existing_hemisphere = existing_data.get("Hemisphere");
+            existing_hour = existing_data.get("Hour");
+            existing_month = existing_data.get("Month");
+            existing_offset = existing_data.get("Offset");
+            existing_week = existing_data.get("Week");
+            existing_value = "%s,%s,%s,%s,%s,%s" % (existing_hemisphere, existing_week, existing_month, existing_day, existing_hour, existing_offset);
         elif (command == 'TuyaMCU'):
             # Return only relevant subset of fn/dp ids, ignoring the rest
             try:

--- a/action_plugins/tasmota.py
+++ b/action_plugins/tasmota.py
@@ -124,15 +124,15 @@ class ActionModule(ActionBase):
         elif (command == 'Template'):
             existing_value = data
         elif (command == 'TimeStd' or command == 'TimeDst' ):
-            display.vv("TimeStd/TimeDst found!");
-            existing_data = data.get(command);
-            existing_day = existing_data.get("Day");
-            existing_hemisphere = existing_data.get("Hemisphere");
-            existing_hour = existing_data.get("Hour");
-            existing_month = existing_data.get("Month");
-            existing_offset = existing_data.get("Offset");
-            existing_week = existing_data.get("Week");
-            existing_value = "%s,%s,%s,%s,%s,%s" % (existing_hemisphere, existing_week, existing_month, existing_day, existing_hour, existing_offset);
+            display.vv("TimeStd/TimeDst found!")
+            existing_data = data.get(command)
+            existing_day = existing_data.get("Day")
+            existing_hemisphere = existing_data.get("Hemisphere")
+            existing_hour = existing_data.get("Hour")
+            existing_month = existing_data.get("Month")
+            existing_offset = existing_data.get("Offset")
+            existing_week = existing_data.get("Week")
+            existing_value = "%s,%s,%s,%s,%s,%s" % (existing_hemisphere, existing_week, existing_month, existing_day, existing_hour, existing_offset)
         elif (command == 'TuyaMCU'):
             # Return only relevant subset of fn/dp ids, ignoring the rest
             try:


### PR DESCRIPTION
This PR adds parsing for TimeStd / TimeDst return values.

(!) the documentation of tasmota is wrong about the commands' notation: TimeDST / TimeSTD. There is another PR incoming to change this in the documentation of tasmota. 