### PR TITLE
Add check if item.value is set

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,3 +3,4 @@
     command: "{{ item.command }}"
     value: "{{ item.value }}"
   with_items: "{{ tasmota_commands }}"
+  when: item.value is defined and item.value

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,4 +3,4 @@
     command: "{{ item.command }}"
     value: "{{ item.value }}"
   with_items: "{{ tasmota_commands }}"
-  when: item.value is defined and item.value
+  when: item.value | string | default(False)


### PR DESCRIPTION
It's a bit hacky to set values only for certain hosts using group_vars or host_vars afaics. 
Using this check, it becomes possible to configure a value with:

```
    - command: Module1
      value: "{{ module1 | default(None)}}"
```

