### PR TITLE
Enable --check mode

### DIFF
--- a/action_plugins/tasmota.py
+++ b/action_plugins/tasmota.py
@@ -191,7 +191,7 @@ class ActionModule(ActionBase):
 
             if not check_mode:
                 change_params = copy.deepcopy(auth_params)
-            change_params.update( { 'cmnd' : ("%s %s" % (command, incoming_value)) } )
+                change_params.update( { 'cmnd' : ("%s %s" % (command, incoming_value)) } )
                 change_response = requests.get(url = endpoint_uri, params = change_params)
                 if status_response.status_code != 200:
                     raise AnsibleRuntimeError("Unexpected response code: %s" % (status_response.status_code))

--- a/action_plugins/tasmota.py
+++ b/action_plugins/tasmota.py
@@ -57,6 +57,9 @@ class ActionModule(ActionBase):
 
         display.v("args: %s" % (self._task.args))
 
+        check_mode = task_vars['ansible_check_mode']
+        display.v("check_mode: %s" % (check_mode))
+
         try:
             # Get the tasmota host
             tasmota_host = self._get_arg_or_var('tasmota_host', task_vars['ansible_host'])
@@ -185,11 +188,13 @@ class ActionModule(ActionBase):
         display.v("[%s] existing_uri: %s" % (tasmota_host, endpoint_uri))
         if existing_value != incoming_value:
             changed = True
-            change_params = copy.deepcopy(auth_params)
+
+            if not check_mode:
+                change_params = copy.deepcopy(auth_params)
             change_params.update( { 'cmnd' : ("%s %s" % (command, incoming_value)) } )
-            change_response = requests.get(url = endpoint_uri, params = change_params)
-            if status_response.status_code != 200:
-               raise AnsibleRuntimeError("Unexpected response code: %s" % (status_response.status_code))
+                change_response = requests.get(url = endpoint_uri, params = change_params)
+                if status_response.status_code != 200:
+                    raise AnsibleRuntimeError("Unexpected response code: %s" % (status_response.status_code))
 
         if warnings:
             display.warning(warnings)


### PR DESCRIPTION
Enable --check mode to run commands without modifying the target. This means we still hit the Tasmota API to get the current value and compare it with the provided value, but we don't call the API to execute the change.