### PR TITLE
Add support for no_log

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ e.g.
         # make sure that TuyaMCU fnId is disabled or missing
       - command: TuyaMCU
         value: 11,0
+    
+        # Example for no_log
+      - command: MqttPassword
+        value: MySafePassword
+        no_log: True
+
 ## Tipps
 
 To avoid specifying `tasmota_commands` for each host using host_vars you can use a construct similar to this:

--- a/action_plugins/tasmota.py
+++ b/action_plugins/tasmota.py
@@ -54,8 +54,10 @@ class ActionModule(ActionBase):
 
         self._task_vars = task_vars
         changed = False
+        no_log = self._play_context.no_log
 
-        display.v("args: %s" % (self._task.args))
+        if not no_log:
+          display.v("args: %s" % (self._task.args))
 
         check_mode = task_vars['ansible_check_mode']
         display.v("check_mode: %s" % (check_mode))
@@ -79,8 +81,8 @@ class ActionModule(ActionBase):
             display.v("got an exception: "+err.message)
             return self._fail_result(result, "error during retrieving parameter '%s'" % (err.message))
 
-        display.v("incoming_value %s" % (incoming_value))
-
+        if not no_log:
+            display.v("incoming_value %s" % (incoming_value))
 
         auth_params = {}
         try:
@@ -184,7 +186,7 @@ class ActionModule(ActionBase):
             except Exception as e:
                 raise AnsibleRuntimeError("Invalid response payload: %s, error: %s" % (data, e))
 
-        display.v("[%s] command: %s, existing_value: '%s', incoming_value: '%s'" % (tasmota_host, command, existing_value, incoming_value))
+        display.v("[%s] command: %s, existing_value: '%s', incoming_value: '%s'" % (tasmota_host, command, existing_value, incoming_value if not no_log else ""))
 
         display.v("[%s] existing_uri: %s" % (tasmota_host, endpoint_uri))
         if existing_value != incoming_value:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,7 @@ tasmota_commands: []
 # enable one shot for the rule
 # - command: Rule1
 #   value: 5
+# set MqttPassword to "MySafePassword" with no_log
+# - command: MqttPassword
+#   value: MySafePassword
+#   no_log: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,4 +2,5 @@
   tasmota:
     command: "{{ item.command }}"
     value: "{{ item.value }}"
+  no_log: "{{ item.no_log | default(omit) }}"
   with_items: "{{ tasmota_commands }}"


### PR DESCRIPTION
PR for #14 

@deveth0 this will hide the log output but in verbose mode the password would still be displayed.
See https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html#ansible-no-log

We have to adjust the internal logging accordingly.