### PR TITLE
Add retry for failed connections (e.g. due to restart)

### DIFF
--- a/action_plugins/tasmota.py
+++ b/action_plugins/tasmota.py
@@ -10,6 +10,9 @@ import json
 import sys
 import copy
 
+from urllib3.util import Retry
+from requests.adapters import HTTPAdapter
+
 from ansible.module_utils._text import to_native
 from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleOptionsError, AnsibleAuthenticationFailure, AnsibleRuntimeError
@@ -90,6 +93,10 @@ class ActionModule(ActionBase):
             display.v("authentication parameters: %s" % (auth_params))
         except:
             pass
+
+        # Enable retries due to reboot of the devices
+        session = requests.Session()
+        session.mount("http://%s" % (tasmota_host), HTTPAdapter(Retry(total=5, backoff_factor=1.0)))
 
         endpoint_uri = "http://%s/cm" % (tasmota_host)
         status_params = copy.deepcopy(auth_params)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # This role needs to have the following PIP components installed
 requests
+urllib3


### PR DESCRIPTION
This commit brings in a basic retry handling for connections to the tasmota devices. 
When restarting the device, it becomes unresponsive for a short time, so retrying is a feasible option imho.