### PR TITLE
Fix #19, MqttTopic is incorrect command

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,8 +14,8 @@
       MqttUser {{ tasmota_mqtt_user }};
       MqttPassword {{ tasmota_mqtt_password }};
       MqttClient {{ tasmota_mqtt_client }};
-      MqttTopic {{ tasmota_mqtt_topic }};
-      MqttFullTopic {{ tasmota_mqtt_fulltopic }};
+      Topic {{ tasmota_mqtt_topic }};
+      FullTopic {{ tasmota_mqtt_fulltopic }};
   when: >
     (tasmota_mqtt_user + tasmota_mqtt_password + tasmota_mqtt_host + tasmota_mqtt_port +
     tasmota_mqtt_client + tasmota_mqtt_topic + tasmota_mqtt_fulltopic)


### PR DESCRIPTION
The topic specific commands Topic and FullTopic should not have Mqtt in front of them. Tasmota was failing to set topic correrctly due this. See https://tasmota.github.io/docs/Commands/#mqtt