### PR TITLE
Fix handling of various types of values

### DIFF
--- a/action_plugins/tasmota.py
+++ b/action_plugins/tasmota.py
@@ -130,13 +130,13 @@ class ActionModule(ActionBase):
             existing_rules = data.get("Rules")
             existing_rule = data.get(command)
             existing_stop_on_error = data.get("StopOnError")
-            if incoming_value in ["0","1","2"]:
+            if str(incoming_value) in ["0","1","2"]:
                 display.vv("disable, enable, toggle rule found")
                 existing_value = self._translateResultStr(existing_value)
-            elif incoming_value in ["4","5"]:
+            elif str(incoming_value) in ["4","5"]:
                 display.vv("disable, enable oneshot")
                 existing_value = self._translateResultStr(existing_once, "4", "5")
-            elif incoming_value.lower().startswith("on"):
+            elif str(incoming_value).lower().startswith("on"):
                 display.vv("rule value found")
                 existing_value = existing_rules
         elif (command.startswith('SetOption')):
@@ -249,7 +249,7 @@ class ActionModule(ActionBase):
         if is_required and ret == None:
             raise AnsibleOptionsError("parameter %s is required" % name)
         else:
-            return str(ret)
+            return ret
 
     def _translateResultStr(self, translate, offValue = "0", onValue = "1"):
       if (translate == "OFF"):

--- a/action_plugins/tasmota.py
+++ b/action_plugins/tasmota.py
@@ -127,7 +127,25 @@ class ActionModule(ActionBase):
         if (command.startswith('Rule')):
             display.vv("rule found!")
             existing_rule = data.get(command)
-            existing_state = existing_rule.get("State")
+            if isinstance(existing_rule, dict):
+                # tasmota version >= 10.0.0
+                # example: {"Rule1":{"State":"OFF",
+                #                    "Once":"OFF",
+                #                    "StopOnError":"OFF",
+                #                    "Length":3,
+                #                    "Free":508,
+                #                    "Rules":"..."}}
+                existing_state = existing_rule.get("State")
+            else:
+                # tasmota version < 10.0.0
+                # example: {"Rule1":"OFF",
+                #           "Once":"OFF",
+                #           "StopOnError":"OFF",
+                #           "Length":3,
+                #           "Free":508,
+                #           "Rules":"..."}}
+                existing_state = existing_value
+                existing_rule = data
             existing_once = existing_rule.get("Once")
             existing_rules = existing_rule.get("Rules")
             existing_stop_on_error = existing_rule.get("StopOnError")

--- a/action_plugins/tasmota.py
+++ b/action_plugins/tasmota.py
@@ -212,6 +212,8 @@ class ActionModule(ActionBase):
                 # encode json if required
                 if isinstance(incoming_value, dict):
                     change_params.update( { 'cmnd' : ("%s %s" % (command, json.dumps(incoming_value))) } )
+                elif incoming_value == '':
+                    change_params.update( { 'cmnd' : ("%s \"\"" % (command)) } )
                 else:
                     change_params.update( { 'cmnd' : ("%s %s" % (command, incoming_value)) } )
 

--- a/action_plugins/tasmota.py
+++ b/action_plugins/tasmota.py
@@ -126,16 +126,20 @@ class ActionModule(ActionBase):
 
         if (command.startswith('Rule')):
             display.vv("rule found!")
-            existing_once = data.get("Once")
-            existing_rules = data.get("Rules")
             existing_rule = data.get(command)
-            existing_stop_on_error = data.get("StopOnError")
+            existing_state = existing_rule.get("State")
+            existing_once = existing_rule.get("Once")
+            existing_rules = existing_rule.get("Rules")
+            existing_stop_on_error = existing_rule.get("StopOnError")
             if str(incoming_value) in ["0","1","2"]:
                 display.vv("disable, enable, toggle rule found")
-                existing_value = self._translateResultStr(existing_value)
-            elif str(incoming_value) in ["4","5"]:
-                display.vv("disable, enable oneshot")
+                existing_value = self._translateResultStr(existing_state)
+            elif str(incoming_value) in ["4","5","6"]:
+                display.vv("disable, enable, toggle oneshot")
                 existing_value = self._translateResultStr(existing_once, "4", "5")
+            elif str(incoming_value) in ["8","9","10"]:
+                display.vv("disable, enable, toggle stop-on-error")
+                existing_value = self._translateResultStr(existing_stop_on_error, "8", "9")
             elif str(incoming_value).lower().startswith("on"):
                 display.vv("rule value found")
                 existing_value = existing_rules
@@ -248,8 +252,7 @@ class ActionModule(ActionBase):
         ret = self._templar.template(ret)
         if is_required and ret == None:
             raise AnsibleOptionsError("parameter %s is required" % name)
-        else:
-            return ret
+        return ret
 
     def _translateResultStr(self, translate, offValue = "0", onValue = "1"):
       if (translate == "OFF"):


### PR DESCRIPTION
I wanted to configure my new set of rebranded Gosund SP111 and stumbled across two issues which this PR shall fix.

1. Empty strings could not be written. Example: Clearing `FriendlyNameX` (X e [1;8])
    The issue here was that just the command name and a single space separating the command from its value were sent. The empty value however needs to be specified as an empty pair of quotes. -> Added special handling for empty string values.
2. Dict values were not handled as intended by the code. While there is special handling for Dicts already in place, this was never triggered because `_get_arg_or_var()` always converted its return value to a string. The symptom was that this string was no proper JSON line (mainly single quotes instead of double quotes) therefore I was not able to configure the tasmota `Template`.
3. Fixed the parsing of the existing values of rules. There seem to have been some variables mixed up, so that the resulting existing values were always `None`. That seems to work now reliably.

With the changes my own playbooks work but I did not test some of the very specific commands not applicable to my devices (or at least to my setup). So please check if the changes may break things in different areas.