### PR TITLE
Fix/minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Available variables are listed below, along with their default values:
         tasmota_mqtt_client: ''
         tasmota_mqtt_topic: ''
         tasmota_mqtt_fulltopic: ''
+        tasmota_mqtt_no_log: true
    
 If tasmota_user and tasmota password are both non-empty, they will be included in the commands to authenticate access.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ tasmota_mqtt_port: ''
 tasmota_mqtt_client: ''
 tasmota_mqtt_topic: ''
 tasmota_mqtt_fulltopic: ''
+tasmota_mqtt_no_log: true
 
 tasmota_commands: []
 # examples:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,4 +21,4 @@
     (tasmota_mqtt_user + tasmota_mqtt_password + tasmota_mqtt_host + tasmota_mqtt_port +
     tasmota_mqtt_client + tasmota_mqtt_topic + tasmota_mqtt_fulltopic)
     | length > 0
-  no_log: true
+  no_log: "{{ tasmota_mqtt_no_log }}"


### PR DESCRIPTION
Hello, 

i updated the example in the readme, because the name of the role was wrong. 
There was an underscore instead of a dash.

I also run in the issue that the mqtt part failed because my `tasmota_mqtt_port` was an integer and not a string and i got no feedback because `no_log` is always `true`. Now the user can switch this to `false`.